### PR TITLE
Path() method was removed.

### DIFF
--- a/StoryLine.Rest.Tests/SyntaxTests.cs
+++ b/StoryLine.Rest.Tests/SyntaxTests.cs
@@ -2,18 +2,22 @@
 using StoryLine.Rest.Actions.Extensions;
 using StoryLine.Rest.Expectations;
 using StoryLine.Rest.Expectations.Extensions;
+using Xunit;
 
 namespace StoryLine.Rest.Tests
 {
     public class SyntaxTests
     {
+        //[Fact]
         public void Test()
         {
             Scenario.New()
                 .When()
                     .Performs<HttpRequest>(x => x
                         .Method("POST")
-                        .Url("/aaaaa")
+                        .Url("/aaaaa?xxx=a")
+                        .QueryParam("a", "b")
+                        .QueryParam("c", "d")
                         .JsonObjectBody(new { a = "a" }))
                 .Then()
                     .Expects<HttpResponse>(x => x

--- a/StoryLine.Rest/Actions/IHttpRequest.cs
+++ b/StoryLine.Rest/Actions/IHttpRequest.cs
@@ -7,7 +7,6 @@ namespace StoryLine.Rest.Actions
         IHttpRequest Service(string value);
         IHttpRequest Method(string value);
         IHttpRequest Url(string value);
-        IHttpRequest Path(string value);
         IHttpRequest QueryParam(string parameter, string value);
         IHttpRequest Header(string header, string value);
         IHttpRequest Body(byte[] value);

--- a/StoryLine.Rest/StoryLine.Rest.csproj
+++ b/StoryLine.Rest/StoryLine.Rest.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard1.4</TargetFramework>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <Version>1.5.0</Version>
+    <Version>1.6.0</Version>
     <PackageLicenseUrl>https://github.com/DiamondDragon/StoryLine.Rest/blob/master/License.txt</PackageLicenseUrl>
     <Copyright>Andrei Salanoi &lt;diamond_dragon@tut.by&gt;</Copyright>
     <PackageProjectUrl>https://github.com/DiamondDragon/StoryLine.Rest</PackageProjectUrl>


### PR DESCRIPTION
* Path() method was removed. Url() is the only method used to configure Url(). Query parameters are appended to this Url() 