### PR TITLE
Fix for GetText() when response body is empty. 

### DIFF
--- a/StoryLine.Rest.Tests/Extensions/ResponseExtensionsTests.cs
+++ b/StoryLine.Rest.Tests/Extensions/ResponseExtensionsTests.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using FluentAssertions;
+using StoryLine.Exceptions;
+using StoryLine.Rest.Extensions;
+using StoryLine.Rest.Services.Http;
+using Xunit;
+
+namespace StoryLine.Rest.Tests.Extensions
+{
+    public class ResponseExtensionsTests
+    {
+        private const string BodyText = "Dragon12345";
+
+        private readonly Response _response;
+
+        public ResponseExtensionsTests()
+        {
+            _response = new Response
+            {
+                Status = 200,
+                Body = Encoding.UTF8.GetBytes(BodyText),
+                Request = new Request
+                {
+                    Service = "Crm",
+                    Method = "GET",
+                    Url = "/v1/test"
+                }
+            };
+        }
+
+        [Fact]
+        public void GetText_When_Request_Validation_Enabled_And_Empty_Text_Should_Throw_Expectation_Exception()
+        {
+            _response.Body = new byte[0];
+
+            Assert.Throws<ExpectationException>(() => _response.GetText());
+        }
+
+        [Fact]
+        public void GetText_When_Request_Validation_Disabled_And_Empty_Text_Should_Return_Empty_Body()
+        {
+            _response.Body = new byte[0];
+
+            _response.GetText(false).Should().BeEmpty();
+        }
+    }
+}

--- a/StoryLine.Rest.Tests/Services/ResponseToTextConverterTests.cs
+++ b/StoryLine.Rest.Tests/Services/ResponseToTextConverterTests.cs
@@ -43,7 +43,7 @@ namespace StoryLine.Rest.Tests.Services
         [Fact]
         public void GetText_When_Null_Response_Should_Throw_ArgumentNullException()
         {
-            Assert.Throws<ArgumentNullException>(() => _underTest.GetText(null));
+            Assert.Throws<ArgumentNullException>(() => _underTest.GetText(null, false));
         }
 
         [Fact]
@@ -51,7 +51,7 @@ namespace StoryLine.Rest.Tests.Services
         {
             A.CallTo(() => _response.Body).Returns(null);
 
-            _underTest.GetText(_response).Should().BeEmpty();
+            _underTest.GetText(_response, false).Should().BeEmpty();
         }
 
         [Fact]
@@ -59,7 +59,7 @@ namespace StoryLine.Rest.Tests.Services
         {
             A.CallTo(() => _response.Body).Returns(new byte[0]);
 
-            _underTest.GetText(_response).Should().BeEmpty();
+            _underTest.GetText(_response, false).Should().BeEmpty();
         }
 
         [Theory]
@@ -69,7 +69,7 @@ namespace StoryLine.Rest.Tests.Services
         {
             A.CallTo(() => _contentTypeProvider.GetCharSet(_headers)).Returns(charSet);
 
-            _underTest.GetText(_response).Should().Be(ResponseBodyContent);
+            _underTest.GetText(_response, false).Should().Be(ResponseBodyContent);
         }
 
         [Fact]
@@ -78,7 +78,7 @@ namespace StoryLine.Rest.Tests.Services
             A.CallTo(() => _contentTypeProvider.GetCharSet(_headers)).Returns("utf-32");
             A.CallTo(() => _response.Body).Returns(Encoding.UTF32.GetBytes("Dragon123"));
 
-            _underTest.GetText(_response).Should().Be("Dragon123");
+            _underTest.GetText(_response, false).Should().Be("Dragon123");
         }
 
         [Fact]
@@ -95,7 +95,7 @@ namespace StoryLine.Rest.Tests.Services
             Config.DefaultEncoding = Encoding.Unicode;
             A.CallTo(() => _response.Body).Returns(Encoding.ASCII.GetBytes("XXXXX"));
 
-            _underTest.GetText(_response).Should().NotBeEmpty();
+            _underTest.GetText(_response, false).Should().NotBeEmpty();
         }
     }
 }

--- a/StoryLine.Rest.Tests/StoryLine.Rest.Tests.csproj
+++ b/StoryLine.Rest.Tests/StoryLine.Rest.Tests.csproj
@@ -20,9 +20,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FakeItEasy" Version="3.4.1" />
-    <PackageReference Include="FluentAssertions" Version="4.19.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="FakeItEasy" Version="4.0.0" />
+    <PackageReference Include="FluentAssertions" Version="4.19.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
   </ItemGroup>

--- a/StoryLine.Rest/Expectations/Services/Expectations/BodyContentExpectation.cs
+++ b/StoryLine.Rest/Expectations/Services/Expectations/BodyContentExpectation.cs
@@ -20,7 +20,7 @@ namespace StoryLine.Rest.Expectations.Services.Expectations
             if (response == null)
                 throw new ArgumentNullException(nameof(response));
 
-            var actualResponseText = Config.ResponseToTextConverter.GetText(response);
+            var actualResponseText = Config.ResponseToTextConverter.GetText(response, false);
 
             if (actualResponseText == null)
                 throw new ExpectationException("Response doesn't contain any text");

--- a/StoryLine.Rest/Expectations/Services/Expectations/ResponseTextBodyExpectation.cs
+++ b/StoryLine.Rest/Expectations/Services/Expectations/ResponseTextBodyExpectation.cs
@@ -20,7 +20,7 @@ namespace StoryLine.Rest.Expectations.Services.Expectations
             if (response == null)
                 throw new ArgumentNullException(nameof(response));
 
-            var text = Config.ResponseToTextConverter.GetText(response);
+            var text = Config.ResponseToTextConverter.GetText(response, false);
 
             if (!_predicate(text))
                 throw new ExpectationException(_message(text));

--- a/StoryLine.Rest/Extensions/ResponseExtensions.cs
+++ b/StoryLine.Rest/Extensions/ResponseExtensions.cs
@@ -5,12 +5,12 @@ namespace StoryLine.Rest.Extensions
 {
     public static class ResponseExtensions
     {
-        public static string GetText(this IResponse response)
+        public static string GetText(this IResponse response, bool failOnEmptyBody = true)
         {
             if (response == null)
                 throw new ArgumentNullException(nameof(response));
 
-            return Config.ResponseToTextConverter.GetText(response);
+            return Config.ResponseToTextConverter.GetText(response, failOnEmptyBody);
         }
     }
 }

--- a/StoryLine.Rest/Services/IResponseToTextConverter.cs
+++ b/StoryLine.Rest/Services/IResponseToTextConverter.cs
@@ -4,6 +4,6 @@ namespace StoryLine.Rest.Services
 {
     public interface IResponseToTextConverter
     {
-        string GetText(IResponse response);
+        string GetText(IResponse response, bool failOnEmptyBody = true);
     }
 }

--- a/StoryLine.Rest/Services/ResponseToTextConverter.cs
+++ b/StoryLine.Rest/Services/ResponseToTextConverter.cs
@@ -14,10 +14,13 @@ namespace StoryLine.Rest.Services
             _contentTypeProvider = contentTypeProvider ?? throw new ArgumentNullException(nameof(contentTypeProvider));
         }
 
-        public string GetText(IResponse response)
+        public string GetText(IResponse response, bool failOnEmptyBody = true)
         {
             if (response == null)
                 throw new ArgumentNullException(nameof(response));
+
+            if (failOnEmptyBody)
+                ValidateRequest(response);
 
             if (response.Body == null)
                 return string.Empty;
@@ -38,6 +41,24 @@ namespace StoryLine.Rest.Services
             {
                 throw new ExpectationException("Failed to convert response into text.", ex);
             }
+        }
+
+        private static void ValidateRequest(IResponse response)
+        {
+            if (response.Body == null || response.Body.Length == 0)
+                throw new ExpectationException("Empty body can't be used to extract text. Request details: " + GetResponseDetails(response));
+        }
+
+        private static string GetResponseDetails(IResponse response)
+        {
+            var builder = new StringBuilder();
+
+            builder.Append("Service=" + response.Request.Service + ", ");
+            builder.Append("Method=" + response.Request.Method + ", ");
+            builder.Append("Url=" + response.Request.Url + ", ");
+            builder.Append("Status=" + response.Status);
+
+            return builder.ToString();
         }
 
         private static Encoding GetEncoding(string charSetName)

--- a/StoryLine.Rest/StoryLine.Rest.csproj
+++ b/StoryLine.Rest/StoryLine.Rest.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard1.4</TargetFramework>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <Version>1.7.0</Version>
+    <Version>1.7.1</Version>
     <PackageLicenseUrl>https://github.com/DiamondDragon/StoryLine.Rest/blob/master/License.txt</PackageLicenseUrl>
     <Copyright>Andrei Salanoi &lt;diamond_dragon@tut.by&gt;</Copyright>
     <PackageProjectUrl>https://github.com/DiamondDragon/StoryLine.Rest</PackageProjectUrl>


### PR DESCRIPTION
* Fix for GetText() when response body is empty. Detailed information about request and missing body is returned in exception message.
* Empty body validation can be turned off.