### PR TITLE
ResponseRecordingEnabled property removed

### DIFF
--- a/StoryLine.Rest/Config.cs
+++ b/StoryLine.Rest/Config.cs
@@ -39,7 +39,7 @@ namespace StoryLine.Rest
             new ResponseFactory()
         );
         private static readonly ResponseAugmentingDecorator ResponseAugmentingDecorator = new ResponseAugmentingDecorator(RestClientInstance);
-        private static readonly ResponseRecordingDecorator ResponseRecordingDecorator = new ResponseRecordingDecorator(ResponseAugmentingDecorator, ResponseLogger, () => ResponseRecordingEnabled);
+        private static readonly ResponseRecordingDecorator ResponseRecordingDecorator = new ResponseRecordingDecorator(ResponseAugmentingDecorator, ResponseLogger);
 
         private static Func<JsonVerifierSettings, ITextVerifier> _jsonVerifierFactory = x => new JsonVerifier(x);
         private static Func<PlainTextVerifierSettings, ITextVerifier> _plainTextVerifierFactory = x => new PlainTextVerifier(x);
@@ -102,8 +102,6 @@ namespace StoryLine.Rest
         }
 
         internal static IRestClient RestClient => ResponseRecordingDecorator;
-
-        public static bool ResponseRecordingEnabled { get; set; } = false;
 
         public static void SetAssemblies(params Assembly[] assemblies)
         {

--- a/StoryLine.Rest/Services/Http/Decorators/ResponseRecordingDecorator.cs
+++ b/StoryLine.Rest/Services/Http/Decorators/ResponseRecordingDecorator.cs
@@ -6,16 +6,13 @@ namespace StoryLine.Rest.Services.Http.Decorators
     {
         private readonly IRestClient _innerClient;
         private readonly IResponseLogger _responseLogger;
-        private readonly Func<bool> _responseRecordingEnabled;
 
         public ResponseRecordingDecorator(
             IRestClient innerClient,
-            IResponseLogger responseLogger,
-            Func<bool> responseRecordingEnabled)
+            IResponseLogger responseLogger)
         {
             _innerClient = innerClient ?? throw new ArgumentNullException(nameof(innerClient));
             _responseLogger = responseLogger ?? throw new ArgumentNullException(nameof(responseLogger));
-            _responseRecordingEnabled = responseRecordingEnabled ?? throw new ArgumentNullException(nameof(responseRecordingEnabled));
         }
 
         public IResponse Send(IRequest request)
@@ -25,8 +22,7 @@ namespace StoryLine.Rest.Services.Http.Decorators
 
             var response = _innerClient.Send(request);
 
-            if (_responseRecordingEnabled())
-                _responseLogger.Add(response);
+            _responseLogger.Add(response);
 
             return response;
         }

--- a/StoryLine.Rest/StoryLine.Rest.csproj
+++ b/StoryLine.Rest/StoryLine.Rest.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard1.4</TargetFramework>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <Version>1.8.0</Version>
+    <Version>1.8.1</Version>
     <PackageLicenseUrl>https://github.com/DiamondDragon/StoryLine.Rest/blob/master/License.txt</PackageLicenseUrl>
     <Copyright>Andrei Salanoi &lt;diamond_dragon@tut.by&gt;</Copyright>
     <PackageProjectUrl>https://github.com/DiamondDragon/StoryLine.Rest</PackageProjectUrl>


### PR DESCRIPTION
`ResponseRecordingEnabled`  seems to be redundant. If no loggers added nothing happens. So this property is not required.