### PR TITLE
Config: make a bunch of configuraiton properties public

### DIFF
--- a/StoryLine.Rest/Config.cs
+++ b/StoryLine.Rest/Config.cs
@@ -59,25 +59,25 @@ namespace StoryLine.Rest
             "TheoryAttribute"
         };
 
-        internal static Func<JsonVerifierSettings, ITextVerifier> JsonVerifierFactory
+        public static Func<JsonVerifierSettings, ITextVerifier> JsonVerifierFactory
         {
             get => _jsonVerifierFactory;
             set => _jsonVerifierFactory = value ?? throw new ArgumentNullException(nameof(value));
         }
 
-        internal static Func<PlainTextVerifierSettings, ITextVerifier> PlainTextVerifierFactory
+        public static Func<PlainTextVerifierSettings, ITextVerifier> PlainTextVerifierFactory
         {
             get => _plainTextVerifierFactory;
             set => _plainTextVerifierFactory = value ?? throw new ArgumentNullException(nameof(value));
         }
 
-        internal static IResourceContentProvider ResourceContentProvider
+        public static IResourceContentProvider ResourceContentProvider
         {
             get => _resourceContentProvider;
             set => _resourceContentProvider = value ?? throw new ArgumentNullException(nameof(value));
         }
 
-        internal static IResponseToTextConverter ResponseToTextConverter
+        public static IResponseToTextConverter ResponseToTextConverter
         {
             get => _responseToTextConverter;
             set => _responseToTextConverter = value ?? throw new ArgumentNullException(nameof(value));

--- a/StoryLine.Rest/StoryLine.Rest.csproj
+++ b/StoryLine.Rest/StoryLine.Rest.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <Version>2.0.0</Version>
+    <Version>2.1.0</Version>
     <PackageLicense>https://github.com/DiamondDragon/StoryLine.Rest/blob/master/License.txt</PackageLicense>
     <Copyright>Andrei Salanoi &lt;diamond_dragon@tut.by&gt;</Copyright>
     <PackageProjectUrl>https://github.com/DiamondDragon/StoryLine.Rest</PackageProjectUrl>


### PR DESCRIPTION
A change has been made to make the following properties public:

+ JsonVerifierFactory;
+ PlainTextVerifierFactory;
+ ResourceContentProvider;
+ ResponseToTextConverter;

These are required in order to allow writing custom expectations much easier.